### PR TITLE
Added two features: tap key to toggle on, commands to disable/enable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 Makes it so that various keybinds can be toggled instead of being held! The keybinds can be configured through the config file, found in the `config` folder and is called `togglewalk_config.json`.
 
+In order to toggle a keybinding on you must briefly tap the key bound to it
+(that is, hold it down for only 0.1 second or less).  If you hold the key down
+for longer than that then when you release the key the keybinding will *not* be
+toggled on.  This means that, for example, you can hold down `w` to walk around
+like normal and when you release `w` you'll stop walking.  To stop a keybinding
+that has been toggled on, again tap the key bound to it.
+
+If you want to temporarily disable toggling you can enter the command `/tw
+off`, then enter `/tw on` to re-enable it.
+
 Requires the [Fabric API](https://minecraft.curseforge.com/projects/fabric).
 
 ## Config

--- a/authors.txt
+++ b/authors.txt
@@ -1,0 +1,6 @@
+* Kaamil Jasani (https://github.com/ExtraCrafTX)
+  Original author of mod
+
+* Matthew Cline (https://github.com/matthew-cline)
+  * Tap key to toggle on
+  * "/tw on" and "/tw off" commands.

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.2.2-SNAPSHOT'
+	id 'fabric-loom' version '0.2.6-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,19 @@
 plugins {
+    // See https://fabricmc.net/wiki/documentation:fabric_loom
 	id 'fabric-loom' version '0.2.6-SNAPSHOT'
+
 	id 'maven-publish'
 }
+
+repositories {
+	maven {
+        // For ClientCommands mod.
+        // See https://github.com/CottonMC/ClientCommands
+		name = 'CottonMC'
+		url = 'http://server.bbkr.space:8081/artifactory/libs-snapshot'
+	}    
+}
+
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
@@ -22,8 +34,11 @@ dependencies {
 	// Fabric API. This is technically optional, but you probably want it anyway.
 	modCompile "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-	// PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
-	// You may need to force-disable transitiveness on them.
+	// See https://github.com/CottonMC/ClientCommands
+	// "include" does jar-in-jar for the ClientCommands mod, so that mod
+	// will be included in our JAR file.
+	modCompile "io.github.cottonmc:cotton-client-commands:${project.cmd_version}"
+	include "io.github.cottonmc:cotton-client-commands:${project.cmd_version}"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,6 @@ org.gradle.jvmargs=-Xmx1G
 
 # Dependencies
 	fabric_version=0.5.1+build.294-1.15
+	# For ClientCommands mod
+	#cmd_version=0.3.0+1.14-SNAPSHOT
+	cmd_version=0.4.2+1.14.3-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.7.8+build.189
 
 # Mod Properties
-	mod_version = 1.1.0
+	mod_version = 1.2.0
 	maven_group = com.extracraftx.minecraft
 	archives_base_name = togglewalk
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,10 +2,11 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
-	# check these on https://fabricmc.net/use
-	minecraft_version=1.14.1
-	yarn_mappings=1.14.1+build.10
-	loader_version=0.4.8+build.154
+	# check these on https://modmuss50.me/fabric.html, or see
+	# https://modmuss50.me/fabric.html
+	minecraft_version=1.15.2
+	yarn_mappings=1.15.2+build.14:v2
+	loader_version=0.7.8+build.189
 
 # Mod Properties
 	mod_version = 1.1.0
@@ -13,5 +14,4 @@ org.gradle.jvmargs=-Xmx1G
 	archives_base_name = togglewalk
 
 # Dependencies
-	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric
-	fabric_version=0.3.0+build.173
+	fabric_version=0.5.1+build.294-1.15

--- a/src/main/java/com/extracraftx/minecraft/togglewalk/ToggleWalk.java
+++ b/src/main/java/com/extracraftx/minecraft/togglewalk/ToggleWalk.java
@@ -71,18 +71,24 @@ public class ToggleWalk implements ClientModInitializer, ClientCommandPlugin {
     }
 
     private void cmdOn(ClientPlayerEntity sender) {
-        sender.addChatMessage(new LiteralText("on on on"), false);
-
+        for(int i = 0; i < bindings.length; i++) {
+            bindings[i].setDisabled(false);
+        }
+        sender.addChatMessage(new LiteralText("toggling enabled"), false);
     }
 
     private void cmdOff(ClientPlayerEntity sender) {
-        sender.addChatMessage(new LiteralText("off off off"), false);
+        for(int i = 0; i < bindings.length; i++) {
+            bindings[i].setDisabled(true);
+        }
+        sender.addChatMessage(new LiteralText("toggling disabled"), false);
     }
 
     private void cmdHelp(ClientPlayerEntity sender) {
-        sender.addChatMessage(new LiteralText("help help"), false);
+        String str = "/tw off: disable ToggleWalk toggling\n" +
+                     "/tw on:  enable ToggleWalk toggling";
+        sender.addChatMessage(new LiteralText(str), false);
     }
-
 
     ////////////////////////////////////////////////////////////////////////
     ////////////////////// ClientModInitializer methods ////////////////////
@@ -118,6 +124,12 @@ public class ToggleWalk implements ClientModInitializer, ClientCommandPlugin {
                 .then(
                     literal("off").executes(c->{
                         instance.cmdOff(MinecraftClient.getInstance().player);
+                        return 1;
+                    })
+                )
+                .then(
+                    literal("help").executes(c->{
+                        instance.cmdHelp(MinecraftClient.getInstance().player);
                         return 1;
                     })
                 )

--- a/src/main/java/com/extracraftx/minecraft/togglewalk/ToggleWalk.java
+++ b/src/main/java/com/extracraftx/minecraft/togglewalk/ToggleWalk.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import com.extracraftx.minecraft.togglewalk.config.Config;
 import com.extracraftx.minecraft.togglewalk.config.Config.Toggle;
 import com.extracraftx.minecraft.togglewalk.interfaces.ToggleableKeyBinding;
+import com.extracraftx.minecraft.togglewalk.mixin.KeyBindingMixin;
 
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.event.client.ClientTickCallback;
@@ -14,44 +15,54 @@ import net.minecraft.client.options.KeyBinding;
 public class ToggleWalk implements ClientModInitializer {
 
     private static Map<String, KeyBinding> keysById;
-    private KeyBinding[] bindings;
-    private KeyBinding[] opposites;
+
+    private ToggleableKeyBinding[] bindings;
+    private KeyBinding[]           opposites;
+    private KeyBinding[]           baseBindings;
 
     @Override
     public void onInitializeClient() {
         ClientTickCallback.EVENT.register((mc)->{
             onTick(mc);
-        });
-    }
+        }); }
 
     public void onTick(MinecraftClient mc){
         if(bindings == null){
-            keysById = ((ToggleableKeyBinding)mc.options.keyForward).getKeysIdMap();
+            keysById = ((ToggleableKeyBinding)mc.options.keyForward).
+                getKeysIdMap();
             load(mc);
         }
-        for(int i = 0; i < bindings.length; i++){
-            KeyBinding kb = bindings[i];
-            KeyBinding opp = opposites[i];
-            if(kb.wasPressed()){
-                ToggleableKeyBinding tkb = (ToggleableKeyBinding)kb;
-                tkb.toggle();
-            }
-            if(opp != null && opp.wasPressed()){
-                ToggleableKeyBinding tkb = (ToggleableKeyBinding)kb;
-                tkb.setToggled(false);
-            }
+
+        if (mc.world == null)
+            // No world yet in which to do anything.
+            return;
+
+        long time = mc.world.getTime();
+        for(int i = 0; i < bindings.length; i++) {
+            // NOTE: KeyBindingMixin can't access KeyBinding.wasPressed(),
+            // so we have to do it for them.
+            boolean pressed    = baseBindings[i].wasPressed();
+            boolean oppPressed = opposites[i] == null ?
+                false : opposites[i].wasPressed();
+            bindings[i].handleToggleTick(time, pressed, oppPressed);
         }
     }
 
     public void load(MinecraftClient mc){
         Config.loadConfigs();
-        bindings = new KeyBinding[Config.INSTANCE.toggles.length];
-        opposites = new KeyBinding[bindings.length];
+
+        bindings     = new ToggleableKeyBinding[Config.INSTANCE.toggles.length];
+        opposites    = new KeyBinding[Config.INSTANCE.toggles.length];
+        baseBindings = new KeyBinding[Config.INSTANCE.toggles.length];
+
         for(int i = 0; i < bindings.length; i++){
-            Toggle toggle = Config.INSTANCE.toggles[i];
-            bindings[i] = keysById.get("key." + toggle.toggle);
-            opposites[i] = keysById.get("key." + toggle.untoggle);
+            Toggle               toggle = Config.INSTANCE.toggles[i];
+
+            baseBindings[i] = keysById.get("key." + toggle.toggle);
+            opposites[i]    = keysById.get("key." + toggle.untoggle);
+            bindings[i]     = (ToggleableKeyBinding) baseBindings[i];
+
+            bindings[i].init( (ToggleableKeyBinding) opposites[i]);
         }
     }
-
 }

--- a/src/main/java/com/extracraftx/minecraft/togglewalk/ToggleWalk.java
+++ b/src/main/java/com/extracraftx/minecraft/togglewalk/ToggleWalk.java
@@ -56,13 +56,11 @@ public class ToggleWalk implements ClientModInitializer {
         baseBindings = new KeyBinding[Config.INSTANCE.toggles.length];
 
         for(int i = 0; i < bindings.length; i++){
-            Toggle               toggle = Config.INSTANCE.toggles[i];
+            Toggle toggle = Config.INSTANCE.toggles[i];
 
             baseBindings[i] = keysById.get("key." + toggle.toggle);
             opposites[i]    = keysById.get("key." + toggle.untoggle);
             bindings[i]     = (ToggleableKeyBinding) baseBindings[i];
-
-            bindings[i].init( (ToggleableKeyBinding) opposites[i]);
         }
     }
 }

--- a/src/main/java/com/extracraftx/minecraft/togglewalk/interfaces/ToggleableKeyBinding.java
+++ b/src/main/java/com/extracraftx/minecraft/togglewalk/interfaces/ToggleableKeyBinding.java
@@ -16,16 +16,4 @@ public interface ToggleableKeyBinding {
      */
     public void handleToggleTick(long time, boolean wasPressed,
                                  boolean oppositeWasPressed);
-
-    /**
-     * We can't directly reference the KeyBindingMixin class from within itself
-     * because of the way the Sponge classloder works, so we can't reference
-     * the private members of other intances of this class.  For instance, this
-     * is illegal run time:
-     *
-     *     opposite.toggled = false;
-     *
-     * Do note that the code will compile, even though it won't run.
-     */
-    public void setToggled(boolean toggled);
 }

--- a/src/main/java/com/extracraftx/minecraft/togglewalk/interfaces/ToggleableKeyBinding.java
+++ b/src/main/java/com/extracraftx/minecraft/togglewalk/interfaces/ToggleableKeyBinding.java
@@ -7,6 +7,7 @@ import net.minecraft.client.options.KeyBinding;
 public interface ToggleableKeyBinding {
     public Map<String,KeyBinding> getKeysIdMap();
 
+    public void setDisabled(boolean disabled);
     /**
      * We can't access the method KeyBinding.wasPressed(), created by Sponge
      * due to injecting into KeyBinding.isPressed(), due to the way that

--- a/src/main/java/com/extracraftx/minecraft/togglewalk/interfaces/ToggleableKeyBinding.java
+++ b/src/main/java/com/extracraftx/minecraft/togglewalk/interfaces/ToggleableKeyBinding.java
@@ -5,7 +5,28 @@ import java.util.Map;
 import net.minecraft.client.options.KeyBinding;
 
 public interface ToggleableKeyBinding {
-    public void                   toggle();
-    public void                   setToggled(boolean value);
+    public void                   init(ToggleableKeyBinding opposite);
     public Map<String,KeyBinding> getKeysIdMap();
+
+    /**
+     * We can't access the method KeyBinding.wasPressed(), created by Sponge
+     * due to injecting into KeyBinding.isPressed(), due to the way that
+     * the Sponge classloader works, so wasPressed() has to be accessed
+     * from within the non-mixin class ToggleWalk and passed to the
+     * KeyBindingMixin class.
+     */
+    public void handleToggleTick(long time, boolean wasPressed,
+                                 boolean oppositeWasPressed);
+
+    /**
+     * We can't directly reference the KeyBindingMixin class from within itself
+     * because of the way the Sponge classloder works, so we can't reference
+     * the private members of other intances of this class.  For instance, this
+     * is illegal run time:
+     *
+     *     opposite.toggled = false;
+     *
+     * Do note that the code will compile, even though it won't run.
+     */
+    public void setToggled(boolean toggled);
 }

--- a/src/main/java/com/extracraftx/minecraft/togglewalk/interfaces/ToggleableKeyBinding.java
+++ b/src/main/java/com/extracraftx/minecraft/togglewalk/interfaces/ToggleableKeyBinding.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import net.minecraft.client.options.KeyBinding;
 
 public interface ToggleableKeyBinding {
-    public void toggle();
-    public void setToggled(boolean value);
+    public void                   toggle();
+    public void                   setToggled(boolean value);
     public Map<String,KeyBinding> getKeysIdMap();
 }

--- a/src/main/java/com/extracraftx/minecraft/togglewalk/interfaces/ToggleableKeyBinding.java
+++ b/src/main/java/com/extracraftx/minecraft/togglewalk/interfaces/ToggleableKeyBinding.java
@@ -5,7 +5,6 @@ import java.util.Map;
 import net.minecraft.client.options.KeyBinding;
 
 public interface ToggleableKeyBinding {
-    public void                   init(ToggleableKeyBinding opposite);
     public Map<String,KeyBinding> getKeysIdMap();
 
     /**

--- a/src/main/java/com/extracraftx/minecraft/togglewalk/mixin/KeyBindingMixin.java
+++ b/src/main/java/com/extracraftx/minecraft/togglewalk/mixin/KeyBindingMixin.java
@@ -17,12 +17,12 @@ import net.minecraft.client.options.KeyBinding;
 public abstract class KeyBindingMixin implements ToggleableKeyBinding{
 
     /**
-     * How much time (in ticks) the player has to release the key after
-     * first pressing it for it to count as a "key tap".
+     * How much time (in ticks) the player has to release the key after first
+     * pressing it for it to count as a "key tap".
      *
      * 20 ticks = 1 second
      */
-    private final static long KEY_TAP_DELAY = 5; // 0.25 seconds
+    private final static long KEY_TAP_DELAY = 2; // 0.1 seconds
 
     private boolean toggled              = false;
     private boolean disabled             = false;

--- a/src/main/java/com/extracraftx/minecraft/togglewalk/mixin/KeyBindingMixin.java
+++ b/src/main/java/com/extracraftx/minecraft/togglewalk/mixin/KeyBindingMixin.java
@@ -15,9 +15,9 @@ import net.minecraft.client.options.KeyBinding;
 
 @Mixin(KeyBinding.class)
 public abstract class KeyBindingMixin implements ToggleableKeyBinding{
-    
     private boolean toggled = false;
 
+    /////////////////////// Implements ToggleableKeyBinding /////////////////
     @Override
     public void toggle() {
         toggled = !toggled;
@@ -27,7 +27,20 @@ public abstract class KeyBindingMixin implements ToggleableKeyBinding{
     public void setToggled(boolean value) {
         toggled = value;
     }
-    
+
+    @Override
+    public Map<String, KeyBinding> getKeysIdMap() {
+        return getKeysById();
+    }
+
+    /////////////////////////// Non-interface methods ////////////////////////
+
+    /*
+     * NOTE: this seems to create a wasPressed() method in
+     * net.minecraft.client.options.KeyBinding which returns what the value
+     * WOULD be if our injected code hadn't messed with anything.  However, I
+     * can't find any documentation for this.
+     */
     @Inject(method = "isPressed", at = @At("HEAD"), cancellable = true)
     public void onIsPressed(CallbackInfoReturnable<Boolean> info) {
         if(toggled){
@@ -39,10 +52,4 @@ public abstract class KeyBindingMixin implements ToggleableKeyBinding{
     public static Map<String, KeyBinding> getKeysById(){
         throw new NotImplementedException("keysById mixin failed to apply.");
     }
-
-    @Override
-    public Map<String, KeyBinding> getKeysIdMap() {
-        return getKeysById();
-    }
-
 }

--- a/src/main/java/com/extracraftx/minecraft/togglewalk/mixin/KeyBindingMixin.java
+++ b/src/main/java/com/extracraftx/minecraft/togglewalk/mixin/KeyBindingMixin.java
@@ -15,25 +15,13 @@ import net.minecraft.client.options.KeyBinding;
 
 @Mixin(KeyBinding.class)
 public abstract class KeyBindingMixin implements ToggleableKeyBinding{
-    private boolean              toggled = false;
-    private ToggleableKeyBinding opposite = null;
+    private boolean toggled = false;
 
     private void toggle() {
         toggled = !toggled;
     }
 
    /////////////////////// Implements ToggleableKeyBinding /////////////////
-
-    @Override
-    public void init(ToggleableKeyBinding opposite) {
-        if (this.opposite != null) {
-            System.err.println("WARNING: init() already called on " +
-                    "KeyBindingMixin");
-            return;
-        }
-
-        this.opposite = opposite;
-    }
 
     /**
      * We can't access the method KeyBinding.wasPressed(), created by Sponge
@@ -45,10 +33,14 @@ public abstract class KeyBindingMixin implements ToggleableKeyBinding{
     @Override
     public void handleToggleTick(long time, boolean wasPressed,
                                  boolean oppositeWasPressed) {
+        if (wasPressed && oppositeWasPressed)
+            System.err.println("ERROR: toggle and untoggle pressed at same " +
+                    "time!!");
+
         if(wasPressed)
             toggle();
         if(oppositeWasPressed)
-            opposite.setToggled(false);
+            setToggled(false);
     }
 
     /**

--- a/src/main/java/com/extracraftx/minecraft/togglewalk/mixin/KeyBindingMixin.java
+++ b/src/main/java/com/extracraftx/minecraft/togglewalk/mixin/KeyBindingMixin.java
@@ -21,7 +21,11 @@ public abstract class KeyBindingMixin implements ToggleableKeyBinding{
         toggled = !toggled;
     }
 
-   /////////////////////// Implements ToggleableKeyBinding /////////////////
+    private void setToggled(boolean toggled) {
+        this.toggled = toggled;
+    }
+
+    /////////////////////// Implements ToggleableKeyBinding /////////////////
 
     /**
      * We can't access the method KeyBinding.wasPressed(), created by Sponge
@@ -41,21 +45,6 @@ public abstract class KeyBindingMixin implements ToggleableKeyBinding{
             toggle();
         if(oppositeWasPressed)
             setToggled(false);
-    }
-
-    /**
-     * We can't directly reference the KeyBindingMixin class here because
-     * of the way the Sponge classloder works, so we can't reference the
-     * private members of other intances of this class.  For instance, this
-     * is illegal run time:
-     *
-     *     opposite.toggled = false;
-     *
-     * Do note that the code will compile, even though it won't run.
-     */
-    @Override
-    public void setToggled(boolean toggled) {
-        this.toggled = toggled;
     }
 
     @Override

--- a/src/main/java/com/extracraftx/minecraft/togglewalk/mixin/KeyBindingMixin.java
+++ b/src/main/java/com/extracraftx/minecraft/togglewalk/mixin/KeyBindingMixin.java
@@ -15,17 +15,55 @@ import net.minecraft.client.options.KeyBinding;
 
 @Mixin(KeyBinding.class)
 public abstract class KeyBindingMixin implements ToggleableKeyBinding{
-    private boolean toggled = false;
+    private boolean              toggled = false;
+    private ToggleableKeyBinding opposite = null;
 
-    /////////////////////// Implements ToggleableKeyBinding /////////////////
-    @Override
-    public void toggle() {
+    private void toggle() {
         toggled = !toggled;
     }
 
+   /////////////////////// Implements ToggleableKeyBinding /////////////////
+
     @Override
-    public void setToggled(boolean value) {
-        toggled = value;
+    public void init(ToggleableKeyBinding opposite) {
+        if (this.opposite != null) {
+            System.err.println("WARNING: init() already called on " +
+                    "KeyBindingMixin");
+            return;
+        }
+
+        this.opposite = opposite;
+    }
+
+    /**
+     * We can't access the method KeyBinding.wasPressed(), created by Sponge
+     * due to injecting into KeyBinding.isPressed(), due to the way that
+     * the Sponge classloader works, so wasPressed() has to be accessed
+     * from within the non-mixin class ToggleWalk and passed to the
+     * KeyBindingMixin class.
+     */
+    @Override
+    public void handleToggleTick(long time, boolean wasPressed,
+                                 boolean oppositeWasPressed) {
+        if(wasPressed)
+            toggle();
+        if(oppositeWasPressed)
+            opposite.setToggled(false);
+    }
+
+    /**
+     * We can't directly reference the KeyBindingMixin class here because
+     * of the way the Sponge classloder works, so we can't reference the
+     * private members of other intances of this class.  For instance, this
+     * is illegal run time:
+     *
+     *     opposite.toggled = false;
+     *
+     * Do note that the code will compile, even though it won't run.
+     */
+    @Override
+    public void setToggled(boolean toggled) {
+        this.toggled = toggled;
     }
 
     @Override
@@ -40,6 +78,11 @@ public abstract class KeyBindingMixin implements ToggleableKeyBinding{
      * net.minecraft.client.options.KeyBinding which returns what the value
      * WOULD be if our injected code hadn't messed with anything.  However, I
      * can't find any documentation for this.
+     *
+     * Also note that do to the way that Sponge works that the wasPressed()
+     * method can't be accessed from within this class, no matter what
+     * coding tricks are done; any attempt to do so in code whill result
+     * in an IllegalClassLoadError at runtime.
      */
     @Inject(method = "isPressed", at = @At("HEAD"), cancellable = true)
     public void onIsPressed(CallbackInfoReturnable<Boolean> info) {

--- a/src/main/java/com/extracraftx/minecraft/togglewalk/mixin/KeyBindingMixin.java
+++ b/src/main/java/com/extracraftx/minecraft/togglewalk/mixin/KeyBindingMixin.java
@@ -25,9 +25,13 @@ public abstract class KeyBindingMixin implements ToggleableKeyBinding{
     private final static long KEY_TAP_DELAY = 5; // 0.25 seconds
 
     private boolean toggled              = false;
+    private boolean disabled             = false;
     private long    key_release_deadline = -1;
 
     private void setToggled(boolean toggled) {
+        if (disabled)
+            toggled = false;
+
         if (this.toggled != toggled)
             key_release_deadline = -1;
 
@@ -46,6 +50,9 @@ public abstract class KeyBindingMixin implements ToggleableKeyBinding{
     @Override
     public void handleToggleTick(long time, boolean wasPressed,
                                  boolean oppositeWasPressed) {
+        if (disabled)
+            return;
+
         if (wasPressed && oppositeWasPressed)
             System.err.println("ERROR: toggle and untoggle pressed at same " +
                     "time!!");
@@ -70,6 +77,15 @@ public abstract class KeyBindingMixin implements ToggleableKeyBinding{
 
         if(oppositeWasPressed)
             setToggled(false);
+    }
+
+    @Override
+    public void setDisabled(boolean disabled) {
+        this.disabled = disabled;
+        if (disabled) {
+            setToggled(false);
+            key_release_deadline = -1;
+        }
     }
 
     @Override

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -6,7 +6,8 @@
   "name": "ToggleWalk",
   "description": "Makes it so that various controls in Minecraft now toggle instead!",
   "authors": [
-    "ExtraCrafTX"
+    "ExtraCrafTX",
+    "Matthew Cline"
   ],
   "contact": {
     "homepage": "https://minecraft.curseforge.com/projects/togglewalk/",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -21,6 +21,9 @@
   "entrypoints": {
     "client": [
       "com.extracraftx.minecraft.togglewalk.ToggleWalk"
+    ],
+    "cotton-client-commands": [
+      "com.extracraftx.minecraft.togglewalk.ToggleWalk"
     ]
   },
   "mixins": [

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "extracraftx_togglewalk",
-  "version": "1.1.0",
+  "version": "1.2.0",
 
   "name": "ToggleWalk",
   "description": "Makes it so that various controls in Minecraft now toggle instead!",


### PR DESCRIPTION
I've added two features to ToggleWalk:

1. To toggle a keybinding on you have to briefly tap the associated key.  If you hold the key down for longer than 0.1 seconds then when you release the key the binding *won't* be toggled on.  This is useful for walking, since you a lot of times you want to move around for a few seconds rather than for a long time.
1. The command `/tw off` will disable toggling and `/tw on` will re-enable toggling.  Note that the code for doing such commands only works for Minecraft 1.15+ and is incompatible with 1.14.  To make it also work with 1.14 there'd have to be a separate 1.14 branch with the code modified to the 1.14 way of doing things, and then the 1.14 and 1.15+ branches would have to be kept in sync for any future changes to the mod.